### PR TITLE
Fixes two generated objects of of java.util.Date() sometimes do not equal

### DIFF
--- a/src/main/java/de/a9d3/testing/testdata/TestDataStatics.java
+++ b/src/main/java/de/a9d3/testing/testdata/TestDataStatics.java
@@ -1,6 +1,7 @@
 package de.a9d3.testing.testdata;
 
 import java.time.Instant;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -70,6 +71,7 @@ public final class TestDataStatics {
 
         map.put(String.class.getName(), x -> "");
         map.put(Instant.class.getName(), x -> Instant.ofEpochSecond(0));
+        map.put(Date.class.getName(), x -> Date.from(Instant.ofEpochSecond(0)));
 
         return map;
     }
@@ -79,6 +81,7 @@ public final class TestDataStatics {
 
         map.put(String.class.getName(), x -> UUID.nameUUIDFromBytes(x.getBytes()).toString());
         map.put(Instant.class.getName(), x -> Instant.ofEpochSecond(x.hashCode()));
+        map.put(Date.class.getName(), x -> Date.from(Instant.ofEpochSecond(x.hashCode())));
 
         return map;
     }

--- a/src/test/java/de/a9d3/testing/testdata/TestDataProviderTest.java
+++ b/src/test/java/de/a9d3/testing/testdata/TestDataProviderTest.java
@@ -9,6 +9,7 @@ import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
 import static org.junit.Assert.*;
@@ -250,5 +251,25 @@ public class TestDataProviderTest {
         provider.addCustomMappings(map);
 
         assertEquals(checkChar, provider.fill(Character.class, "123", false));
+    }
+
+    @Test
+    public void regressionDateTest() throws InterruptedException {
+        // referencing https://github.com/Mixermachine/base-test/issues/66
+        provider = TestDataProvider.getDefaultTestDataProvider();
+        assertTrue("Test failed for defaultTestDataProvider", checkIfTwoDatesAreEqualIfProducedWithDelay(provider));
+
+        provider = TestDataProvider.getSeededTestDataProvider();
+        assertTrue("Test failed for defaultTestDataProvider", checkIfTwoDatesAreEqualIfProducedWithDelay(provider));
+    }
+
+    private boolean checkIfTwoDatesAreEqualIfProducedWithDelay(TestDataProvider customProvider) throws InterruptedException {
+        Supplier<Date> supplier = () -> customProvider.fill(Date.class, "123", false);
+
+        Date date1 = supplier.get();
+        Thread.sleep(1);
+        Date date2 = supplier.get();
+
+        return date1.equals(date2);
     }
 }


### PR DESCRIPTION
...if time has passed between generation. Fixes #66